### PR TITLE
Use := to define optional parameters

### DIFF
--- a/JControlWriter.ahk
+++ b/JControlWriter.ahk
@@ -39,7 +39,7 @@ CleanUp:
 ExitJavaAccessBridge()
 ExitApp
 
-OpenJControlDlg(hwnd, visible=1)
+OpenJControlDlg(hwnd, visible:=1)
 {
 global 13JCtrlLVVar, 13Searchfield, 13GuiHwnd
 if (hwnd="A")
@@ -178,7 +178,7 @@ return
 13FindText(0)
 return
 
-13FindText(addline=1)
+13FindText(addline:=1)
 {
 global 13Searchfield
 Gui, 13: Default
@@ -357,7 +357,7 @@ Gui, 14: Destroy
 JCWSettings.13JWinVisibleChildren:=
 return
 
-LoadResourceStrings(ResourceFile, byref BaseObject, Language="English")
+LoadResourceStrings(ResourceFile, byref BaseObject, Language:="English")
 {
 If (IsObject(BaseObject))
 {
@@ -393,7 +393,7 @@ Return, tline
 class ApplicationSettingsClass
 {
 
-__New(IniFile="", Section="Main")
+__New(IniFile:="", Section:="Main")
 {
 ApplicationSettingsClass.hidden[this]:= { ASVars: [], ASConsts: [], ASInis: []}
 ApplicationSettingsClass.hidden[this].IniFilePath:=IniFile
@@ -445,7 +445,7 @@ return, value
 }
 }
 
-SetIni(VarName, DefaultValue="")
+SetIni(VarName, DefaultValue:="")
 {
 If (ApplicationSettingsClass.hidden[this].ASConsts.HasKey(VarName))
 {

--- a/JavaAccessBridge.ahk
+++ b/JavaAccessBridge.ahk
@@ -62,7 +62,7 @@ GetTextInfo()
 	;~ ; backgroundColor, foregroundColor, fontFamily, fontSize,
 	;~ ; alignment, bidiLevel, firstLineIndent, leftIndent, rightIndent,
 	;~ ; lineSpacing, spaceAbove, spaceBelow, fullAttributesString
-	;~ GetTextAttributesInRange(vmID, ac, startc=0, endc=0)
+	;~ GetTextAttributesInRange(vmID, ac, startc:=0, endc:=0)
 				;~ txt.=" : "  " : "  " : "  "`n"
 				
 			}
@@ -82,7 +82,7 @@ GetTextInfo()
 ; - check pos: tries if the object has a valid screen location
 ; - left/double/right/middle click; wheel up/down: performs the respective mouse action in the center of the control
 
-JavaControlDoAction(hwnd=0, name="", role="", description="", occurrence="", action="", times=1, parentcontext=0)
+JavaControlDoAction(hwnd:=0, name:="", role:="", description:="", occurrence:="", action:="", times:=1, parentcontext:=0)
 {
 	global JABVariables
 	rval:=JavaControlGet(hwnd, name, role, description, occurrence, parentcontext)
@@ -147,7 +147,7 @@ JavaControlDoAction(hwnd=0, name="", role="", description="", occurrence="", act
 	 return, rval
 }
 
-JavaControlGet(hwnd=0, name="", role="", description="", occurrence="", parentcontext=0)
+JavaControlGet(hwnd:=0, name:="", role:="", description:="", occurrence:="", parentcontext:=0)
 {
 	global JABVariables
 	if (!JABVariables["JABInitialised"])
@@ -230,7 +230,7 @@ JavaControlGet(hwnd=0, name="", role="", description="", occurrence="", parentco
 	}
 }
 
-FindVisibleChild(vmID, ac, name="", role="", description="")
+FindVisibleChild(vmID, ac, name:="", role:="", description:="")
 {
 	global JABVariables
 	retval:=""
@@ -308,7 +308,7 @@ RecurseVisibleChildren(vmID, ac, byref Children)
 	}
 }
 
-GetControlTree(vmID, ac, Invisible=0)
+GetControlTree(vmID, ac, Invisible:=0)
 {
 	global JABVariables
 	RetObj:=Object()
@@ -390,7 +390,7 @@ RecurseAllChildren(vmID, ac, byref Children)
 }
 
 ; performs mouse clicks in the center of the specified control
-MouseClickJControl(byref Info, action="left", count=1)
+MouseClickJControl(byref Info, action:="left", count:=1)
 {
 	If !(Info["X"]=-1 and Info["Width"]=-1 and Info["Y"]=-1 and Info["Height"]=-1)
 	{
@@ -420,7 +420,7 @@ MouseClickJControl(byref Info, action="left", count=1)
 ; Java Access Bridge functions; see Access Bridge documentation for details
 
 ; Initialises the bridge access
-InitJavaAccessBridge(ForceLegacy=0)
+InitJavaAccessBridge(ForceLegacy:=0)
 {
 	global JABVariables
 	JABVariables:= Object()
@@ -1067,7 +1067,7 @@ RequestFocus(vmID, ac)
 
 ; retrieves information about a certain text element as an object with the keys: 
 ; CharCount, CaretIndex, IndexAtPoint
-GetAccessibleTextInfo(vmID, ac, x=0, y=0)
+GetAccessibleTextInfo(vmID, ac, x:=0, y:=0)
 {
 	global JABVariables
 	TempInfo:=Object()
@@ -1322,7 +1322,7 @@ GetAccessibleTextLineBounds(vmID, ac, Index)
 }
 
 ; retrieves text between start and end index
-GetAccessibleTextRange(vmID, ac, startc=0, endc=0)
+GetAccessibleTextRange(vmID, ac, startc:=0, endc:=0)
 {
 	global JABVariables
 	TempStr:=""
@@ -1575,7 +1575,7 @@ GetAccessibleTextItems(vmID, ac, Index)
 ; backgroundColor, foregroundColor, fontFamily, fontSize,
 ; alignment, bidiLevel, firstLineIndent, leftIndent, rightIndent,
 ; lineSpacing, spaceAbove, spaceBelow, fullAttributesString
-GetTextAttributesInRange(vmID, ac, startc=0, endc=0)
+GetTextAttributesInRange(vmID, ac, startc:=0, endc:=0)
 {
 	global JABVariables
 	TempInfo:=Object()

--- a/JavaAccessBridge_class.ahk
+++ b/JavaAccessBridge_class.ahk
@@ -11,7 +11,7 @@ class JavaAccessBridge extends JavaAccessBridgeBase
 	; - focus: attempts to focus the control and left clicks it if focusing fails
 	; - check pos: tries if the object has a valid screen location
 	; - left/double/right/middle click; wheel up/down: performs the respective mouse action in the center of the control
-	ControlDoAction(HWND=0, Name="", Role="", Description="", Occurrence="", Action="", Times=1, ParentContext=0)
+	ControlDoAction(HWND:=0, Name:="", Role:="", Description:="", Occurrence:="", Action:="", Times:=1, ParentContext:=0)
 	{
 		control:=this.ControlGet(HWND, Name, Role, Description, Occurrence, ParentContext)
 		If (control>0)
@@ -56,7 +56,7 @@ class JavaAccessBridge extends JavaAccessBridgeBase
 			return control
 	}
 
-	ControlGet(HWND=0, Name="", Role="", Description="", Occurrence="", ParentContext=0)
+	ControlGet(HWND:=0, Name:="", Role:="", Description:="", Occurrence:="", ParentContext:=0)
 	{
 		root:=0
 		If (ParentContext__Class()="JavaAccessibleContext"))
@@ -310,7 +310,7 @@ class JavaAccessBridgeBase
 	static ACCESSIBLE_EDITBAR:="editbar"
 	static PROGRESS_MONITOR:="progress monitor"
 	
-	__New(ForceLegacy=0)
+	__New(ForceLegacy:=0)
 	{
 		if (ForceLegacy=1)
 		{
@@ -600,7 +600,7 @@ class JavaAccessibleContext
 		DllCall(this.JAB.DLLVersion "\ReleaseJavaObject", "Int", this.vmID, this.JAB.acType, this.ac, "Cdecl")
 	}
 	
-	GetVisibleChild(Name="", Role="", Description="")
+	GetVisibleChild(Name:="", Role:="", Description:="")
 	{
 		retval:=0
 		Info:=this.GetAccessibleContextInfo()
@@ -694,7 +694,7 @@ class JavaAccessibleContext
 		}
 	}
 	
-	GetControlTree(Invisible=0)
+	GetControlTree(Invisible:=0)
 	{
 		RetObj:=Object()
 		Info:=this.GetAccessibleContextInfo()
@@ -712,7 +712,7 @@ class JavaAccessibleContext
 	}
 
 	; performs mouse clicks in the center of the specified control
-	MouseClick(action="left", count=1)
+	MouseClick(action:="left", count:=1)
 	{
 		Info:=this.GetAccessibleContextInfo()
 		If !(Info["X"]=-1 and Info["Width"]=-1 and Info["Y"]=-1 and Info["Height"]=-1)
@@ -928,7 +928,7 @@ class JavaAccessibleContext
 
 	; retrieves information about a certain text element as an object with the keys: 
 	; CharCount, CaretIndex, IndexAtPoint
-	GetAccessibleTextInfo(x=0, y=0)
+	GetAccessibleTextInfo(x:=0, y:=0)
 	{
 		VarSetCapacity(Info, 12,0)
 		if (DllCall(this.JAB.DLLVersion "\getAccessibleTextInfo", "Int", this.vmID, this.JAB.acType, this.ac, "Ptr", &Info, "Int", x, "Int", y, "Cdecl Int"))
@@ -961,7 +961,7 @@ class JavaAccessibleContext
 	}
 
 	; retrieves text between start and end index
-	GetAccessibleTextRange(startc=0, endc=0)
+	GetAccessibleTextRange(startc:=0, endc:=0)
 	{
 		TInfo:=this.GetAccessibleTextInfo()
 		If IsObject(TInfo)
@@ -1051,7 +1051,7 @@ class JavaAccessibleContext
 	; backgroundColor, foregroundColor, fontFamily, fontSize,
 	; alignment, bidiLevel, firstLineIndent, leftIndent, rightIndent,
 	; lineSpacing, spaceAbove, spaceBelow, fullAttributesString
-	GetTextAttributesInRange(startc=0, endc=0)
+	GetTextAttributesInRange(startc:=0, endc:=0)
 	{
 		VarSetCapacity(Info, 3644,0)
 		len:=endc-startc+1
@@ -1110,7 +1110,7 @@ class JavaAccessibleContext
 	
 	; retrieves the caret location as an object with the keys: 
 	; Index, X, Y, Width, Height
-	GetCaretLocation(Index=0)
+	GetCaretLocation(Index:=0)
 	{
 		VarSetCapacity(Info, 16,0)
 		Index:=0


### PR DESCRIPTION
The [AutoHotkey documentation](https://autohotkey.com/docs/Functions.htm#optional) recommends using := to define optional parameters "for consistency with expression assignments and compatibility with future versions of AutoHotkey."
